### PR TITLE
Movin' to Libera

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,7 +46,7 @@ WILUG(7)                   Internet Reference Manual                  WILUG(7)
 
         A list of Wisconsin LUGs can be found at <a href="http://wisconsinlinux.org/">http://wisconsinlinux.org/</a>.
 
-        <a href="http://www.cafepress.com/wilug">threads(3)</a>, <a href="http://www.last.fm/group/wilug">tunes(1)</a>, <a href="http://www.facebook.com/group.php?gid=2254630212">stalkers(6)</a>
+        <a href="http://www.cafepress.com/wilug">threads(3)</a>, <a href="http://www.facebook.com/group.php?gid=2254630212">stalkers(6)</a>
 
 <a name="history"><em>HISTORY</em></a>
         #wilug was created on irc.freenode.net by lt_kije on 30 January, 2006.
@@ -83,7 +83,7 @@ WILUG(7)                   Internet Reference Manual                  WILUG(7)
         There. YOU'RE WELCOME.
 
         A while ago, the RAID volume that hosted wilug.org (don't use that
-        one)went away. On 15 September, 2011, lt_kije brought it back and
+        one) went away. On 15 September, 2011, lt_kije brought it back and
         moved the site to <a href="http://wilug.github.com/">wilug.github.com</a> since the old
         registrations had expired.
 

--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@ WILUG(7)                   Internet Reference Manual                  WILUG(7)
 
         <span class="arg">thing</span> may be one of the following options:
 
-        <a href="#">irc</a>     We hang out on <a href="http://freenode.net/">irc.freenode.net</a> in the channel <a href="irc://chat.freenode.net/wilug">#wilug</a>. 
+        <a href="#">irc</a>     We hang out on <a href="https://libera.chat/">irc.libera.chat</a> in the channel <a href="irc://irc.libera.chat/wilug">#wilug</a>.
 
         <a href="#">http</a>    You're already here.
 
@@ -87,12 +87,19 @@ WILUG(7)                   Internet Reference Manual                  WILUG(7)
         moved the site to <a href="http://wilug.github.com/">wilug.github.com</a> since the old
         registrations had expired.
 
-<a name="bugs"><em>BUGS</em></a>
-        rizbot, freenode. Apparently, this webpage can be used to find our IRC
-        channel. That is bizarre.
+        On 19 May, 2021, the great <a href="https://gist.github.com/joepie91/df80d8d36cd9d1bde46ba018af497409/">Freenode Implosion Of 2021</a> happened and
+        we scurried over to <a href="https://libera.chat/">Libera</a>.  Hopefully we have not been too hasty.
 
-        Also, lt_kije always has to do the writing. It's not hard to <a href="https://github.com/wilug/wilug.github.com">submit a
-        patch</a>. Just sayin'.
+<a name="bugs"><em>BUGS</em></a>
+        Apparently, this webpage can be used to find our IRC channel. That
+        is bizarre.
+
+        <a href="https://github.com/wilug/wilug.github.com">Submitting patches still requires a keyboard</a>. LAME.
+
+<a name="bugs"><em>BUGS EMERITUS</em></a>
+        rizbot
+
+        FreeNode
 
 <a name="bugs"><em>HITS</em></a>
         You are our 000,000,001th visitor!


### PR DESCRIPTION
The Great Freenode Implosion of 2021 is upon us, and the few remaining stragglers who have yet to abandon #wilug IRC are keen to move over to Libera.  Perhaps someday this page will be viewed by a human looking for Wisconsin Linux activities, and send them over to this exciting new venue.

Also, hello to all y'all from the past!  Hope things are going swimmingly.